### PR TITLE
Adding the ability to handle !stats messages in Twitch chat

### DIFF
--- a/MvcChatBot.Agent/MvcChatBot.Agent.csproj
+++ b/MvcChatBot.Agent/MvcChatBot.Agent.csproj
@@ -15,8 +15,7 @@
       <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.5" />
       <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.5" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.5" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.5" />
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.5" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.5" />      
       <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.5" />
       <PackageReference Include="RestSharp" Version="104.4.0" />
       <PackageReference Include="trellonet" Version="0.6.2" />

--- a/MvcChatBot.Agent/Services/TwitchApiService.cs
+++ b/MvcChatBot.Agent/Services/TwitchApiService.cs
@@ -17,7 +17,7 @@ namespace MvcChatBot.Agent.Services
         private TwitchAPI API;
         //private FollowerService FollowerService;
         private readonly TwitchSettings _settings;
-        private readonly HubConnection _connection;        
+        private readonly HubConnection _connection;  
 
         public TwitchApiService(TwitchSettings settings, HubConnection connection)
         {
@@ -42,7 +42,7 @@ namespace MvcChatBot.Agent.Services
         private async Task<string> GetStatsAsync()
         {
             var currentStream = await API.V5.Streams.GetStreamByUserAsync(_settings.ChannelId);
-            return $"Current stats for LaylaCodesIt: {currentStream.Stream.Viewers} viewers, {currentStream.Stream.Channel.Views} views and {currentStream.Stream.Channel.Followers}.";
+            return $"Current stats for {currentStream.Stream.Channel.DisplayName}: {currentStream.Stream.Viewers} viewers, {currentStream.Stream.Channel.Views} views and {currentStream.Stream.Channel.Followers}.";
         }
 
         private async Task ConfigLiveMonitorAsync()

--- a/MvcChatBot.Agent/Services/TwitchApiService.cs
+++ b/MvcChatBot.Agent/Services/TwitchApiService.cs
@@ -32,14 +32,7 @@ namespace MvcChatBot.Agent.Services
             //Task.Run(() => ConfigLiveMonitorAsync());
         }
 
-        public string GetCurrentStats()
-        {
-            Task<string> task = Task.Run(async () => await GetStatsAsync());
-            task.Wait();
-            return task.Result;
-        }
-
-        private async Task<string> GetStatsAsync()
+        public async Task<string> GetStatsAsync()
         {
             var currentStream = await API.V5.Streams.GetStreamByUserAsync(_settings.ChannelId);
             return $"Current stats for {currentStream.Stream.Channel.DisplayName}: {currentStream.Stream.Viewers} viewers, {currentStream.Stream.Channel.Views} views and {currentStream.Stream.Channel.Followers}.";

--- a/MvcChatBot.Agent/Services/TwitchApiService.cs
+++ b/MvcChatBot.Agent/Services/TwitchApiService.cs
@@ -17,14 +17,32 @@ namespace MvcChatBot.Agent.Services
         private TwitchAPI API;
         //private FollowerService FollowerService;
         private readonly TwitchSettings _settings;
-        private readonly HubConnection _connection;
+        private readonly HubConnection _connection;        
 
         public TwitchApiService(TwitchSettings settings, HubConnection connection)
         {
-            _settings = settings;
+            _settings = settings;           
+
+            API = new TwitchAPI();
+            API.Settings.ClientId = _settings.ClientId;
+            API.Settings.AccessToken = _settings.ChannelAuthToken;
+
             _connection = connection;
             _connection.StartAsync();
-            Task.Run(() => ConfigLiveMonitorAsync());
+            //Task.Run(() => ConfigLiveMonitorAsync());
+        }
+
+        public string GetCurrentStats()
+        {
+            Task<string> task = Task.Run(async () => await GetStatsAsync());
+            task.Wait();
+            return task.Result;
+        }
+
+        private async Task<string> GetStatsAsync()
+        {
+            var currentStream = await API.V5.Streams.GetStreamByUserAsync(_settings.ChannelId);
+            return $"Current stats for LaylaCodesIt: {currentStream.Stream.Viewers} viewers, {currentStream.Stream.Channel.Views} views and {currentStream.Stream.Channel.Followers}.";
         }
 
         private async Task ConfigLiveMonitorAsync()

--- a/MvcChatBot.Agent/Services/TwitchClientService.cs
+++ b/MvcChatBot.Agent/Services/TwitchClientService.cs
@@ -24,6 +24,7 @@ namespace MvcChatBot.Agent.Services
     {
         private readonly TwitchClient _client;
         private readonly TwitchSettings _settings;
+        private readonly TwitchApiService _twitchApiService;
         private readonly HubConnection _connection;
         private readonly TrelloService _trelloService;
         private List<User> liveCodersTeamMembers;
@@ -36,11 +37,9 @@ namespace MvcChatBot.Agent.Services
             TrelloService trelloService)
         {
             _settings = settings;
-            _connection = connection;
+            _connection = connection;           
             _trelloService = trelloService;
             _connection.StartAsync();
-
-
 
             ConnectionCredentials credentials = new ConnectionCredentials(_settings.BotName, _settings.AuthToken);
             var clientOptions = new ClientOptions
@@ -63,6 +62,8 @@ namespace MvcChatBot.Agent.Services
             _client.OnConnected += Client_OnConnected;
 
             _client.Connect();
+            
+            _twitchApiService = new TwitchApiService(_settings, _connection);
 
         }
         private void Client_OnLog(object sender, OnLogArgs e)
@@ -103,7 +104,10 @@ namespace MvcChatBot.Agent.Services
                 }
             }
 
-
+            if(e.ChatMessage.Message.StartsWith("!stats"))
+            {
+                _client.SendMessage(e.ChatMessage.Channel, _twitchApiService.GetCurrentStats());
+            }
         }
         private async Task<List<User>> GetTeamMembers(string teamName)
         {

--- a/MvcChatBot.Agent/Services/TwitchClientService.cs
+++ b/MvcChatBot.Agent/Services/TwitchClientService.cs
@@ -37,7 +37,7 @@ namespace MvcChatBot.Agent.Services
             TrelloService trelloService)
         {
             _settings = settings;
-            _connection = connection;           
+            _connection = connection;        
             _trelloService = trelloService;
             _connection.StartAsync();
 
@@ -104,7 +104,7 @@ namespace MvcChatBot.Agent.Services
                 }
             }
 
-            if(e.ChatMessage.Message.StartsWith("!stats"))
+            if(e.ChatMessage.MFFessage.StartsWith("!stats"))
             {
                 _client.SendMessage(e.ChatMessage.Channel, _twitchApiService.GetCurrentStats());
             }


### PR DESCRIPTION
## Context
Owing to the new goals around things such as followers (yay purple hair!), I thought it would be good to have a !stats command available in chat, like you get in [Nightbot](https://nightbot.tv).

## Changes

### TwitchApiService.cs

All the information is available from the stream endpoint in TwitchLib, so an additional async and synchronous methods have been created to add the ability to fetch this information in a usefully formatted string. We have the two methods due to the client service using synchronous calls.

### TwitchClientService.cs

Introduced a variable so we can access TwitchApiService from within this class.

This now has a check in the OnMessageReceived event listener for any message that starts with !stats which then calls the method to get the formatted string and sends it as a message to chat.

## Note to maintainers
There may be a better way to handle this, I won't be offended if you need to butcher it :D